### PR TITLE
Fix map camera

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,7 +49,7 @@ const App : React.FC<Props> = (props) => {
 			<UserContext.Provider value={user}>
 				<div className={styles.container}>
 					<div className={styles.mapContainer}>
-						<Map lixeiras={lixeiras} center={(selectedEntity instanceof Lixeira) && selectedEntity?.geometry.coordinates}/>
+						<Map lixeiras={lixeiras} center={selectedTab == 'lixeiras' && (selectedEntity as Lixeira)?.geometry.coordinates}/>
 					</div>
 					<div className={styles.foreground}>
 						<div className={styles.searchCardContainer}>


### PR DESCRIPTION
Corrige a condição da tipagem da entidade selecionada em index. Assim a prop referente a lixeira selecionada é passada corretamente para o mapa e a animação da câmera volta a ocorrer.