### PR TITLE
Adiciona admin na copia do patch da lixeira

### DIFF
--- a/src/api/controllers/lixeiraController.ts
+++ b/src/api/controllers/lixeiraController.ts
@@ -41,6 +41,7 @@ router.patch('/', async (req, res) => {
                         "coordinates": [req.body.geometry.coordinates[0], req.body.geometry.coordinates[1]]
                     },
                     "properties": {
+                        "admin" : req.body.properties.admin,
                         "location": req.body.properties.location,
                         "description": req.body.properties.description,
                         "capacity": req.body.properties.capacity,


### PR DESCRIPTION
Alterar uma lixeira não apaga mais o admin.